### PR TITLE
support for varibales

### DIFF
--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -40,6 +40,8 @@ module.exports = function(grunt) {
         varibales = varibales + '- ' + key + '="' + val + '"' + "\n";
       });
 
+      max = varibales + max;
+
       // Make sure grunt creates the destination folders
       grunt.file.write(f.dest, '');
 

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -33,6 +33,13 @@ module.exports = function(grunt) {
         return grunt.file.read(filepath);
       }).join(grunt.util.normalizelf(grunt.util.linefeed));
 
+      // support for varibales
+      var varibales = "";
+
+      grunt.util._.forEach(options.variables, function(val,key){
+        varibales = varibales + '- ' + key + '="' + val + '"' + "\n";
+      });
+
       // Make sure grunt creates the destination folders
       grunt.file.write(f.dest, '');
 


### PR DESCRIPTION
# example:
### gruntfile.coffee

``` coffeescript
module.exports = (grunt)->

  grunt.initConfig

    slim:

      dist:
        options:
          variables: 
            ext: ".min"

        files: "index.html" : "index.slim"

      dev:
        options:
          pretty: true
          variables:
            ext: ""

        files: "index.html" : "index.slim"

  grunt.loadNpmTasks 'grunt-slim'
```
### index.slim

``` slim
link href="/assets/foundation#{ext}.css"
script src="/assets/angular#{ext}.js"
```
