### PR TITLE
Created option bundleExec to run slim through bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 tmp
 .ruby-version
 Gemfile
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 npm-debug.log
 tmp
+.ruby-version
+Gemfile

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Type: `Boolean`
 
 Show a full traceback on error.
 
+#### bundleExec
+Type: `Boolean`
+
+Run `slimrb` preceding it with `bundle exec`.
+
 #### compile
 Type: `Boolean`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-slim",
   "description": "Compile Slim to HTML",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/matsumos/grunt-slim",
   "author": {
     "name": "Keiichiro Matsumoto",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-slim",
   "description": "Compile Slim to HTML",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/matsumos/grunt-slim",
   "author": {
     "name": "Keiichiro Matsumoto",

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -45,8 +45,16 @@ module.exports = function(grunt) {
       // Make sure grunt creates the destination folders
       grunt.file.write(f.dest, '');
 
+      var win32exe = 'slimrb.bat'
+      var nixexe = 'slimrb'
+
+      if (options.bundleExec) {
+        win32exe = 'bundle exec ' + win32exe
+        nixexe = 'bundle exec ' + nixexe
+      }
+
       var slim = grunt.util.spawn({
-        cmd: process.platform === 'win32' ? 'slimrb.bat' : 'slimrb',
+        cmd: process.platform === 'win32' ? win32exe : nixexe,
         args: args
       }, function(error, result, code) {
         if (code === 127) {

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -53,8 +53,8 @@ module.exports = function(grunt) {
         nixexe = 'bundle exec ' + nixexe;
       }
 
-      grunt.warn('exes')
-      grunt.warn(nixexe)
+      grunt.log.info('exes')
+      grunt.log.info(nixexe)
 
       var slim = grunt.util.spawn({
         cmd: process.platform === 'win32' ? win32exe : nixexe,

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -53,6 +53,8 @@ module.exports = function(grunt) {
         nixexe = 'bundle exec ' + nixexe;
       }
 
+      console.log(nixexe)
+
       var slim = grunt.util.spawn({
         cmd: process.platform === 'win32' ? win32exe : nixexe,
         args: args

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -19,6 +19,10 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     grunt.util.async.forEachSeries(this.files, function(f, next) {
+      var bundleExec = options.bundleExec;
+      if (bundleExec) {
+        delete options.bundleExec;
+      }
       var args = [f.dest, '--stdin'].concat(helpers.optsToArgs(options));
 
       grunt.log.writeln(args)
@@ -51,7 +55,7 @@ module.exports = function(grunt) {
       var nixexe = 'slimrb';
       var exeFile = process.platform === 'win32' ? win32exe : nixexe;
 
-      if (options.bundleExec) {
+      if (bundleExec) {
         args.unshift(exeFile)
         args.unshift('exec')
         exeFile = 'bundle';

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -47,17 +47,16 @@ module.exports = function(grunt) {
 
       var win32exe = 'slimrb.bat';
       var nixexe = 'slimrb';
+      var exeFile = process.platform === 'win32' ? win32exe : nixexe;
 
       if (options.bundleExec) {
-        win32exe = 'bundle exec ' + win32exe;
-        nixexe = 'bundle exec ' + nixexe;
+        args.unshift(exeFile)
+        args.unshift('exec')
+        exeFile = 'bundle';
       }
 
-      grunt.log.writeln('exes')
-      grunt.log.writeln(nixexe)
-
       var slim = grunt.util.spawn({
-        cmd: process.platform === 'win32' ? win32exe : nixexe,
+        cmd: exeFile,
         args: args
       }, function(error, result, code) {
         if (code === 127) {

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -45,12 +45,12 @@ module.exports = function(grunt) {
       // Make sure grunt creates the destination folders
       grunt.file.write(f.dest, '');
 
-      var win32exe = 'slimrb.bat'
-      var nixexe = 'slimrb'
+      var win32exe = 'slimrb.bat';
+      var nixexe = 'slimrb';
 
       if (options.bundleExec) {
-        win32exe = 'bundle exec ' + win32exe
-        nixexe = 'bundle exec ' + nixexe
+        win32exe = 'bundle exec ' + win32exe;
+        nixexe = 'bundle exec ' + nixexe;
       }
 
       var slim = grunt.util.spawn({

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -53,7 +53,8 @@ module.exports = function(grunt) {
         nixexe = 'bundle exec ' + nixexe;
       }
 
-      console.log(nixexe)
+      grunt.warn('exes')
+      grunt.warn(nixexe)
 
       var slim = grunt.util.spawn({
         cmd: process.platform === 'win32' ? win32exe : nixexe,

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -21,6 +21,8 @@ module.exports = function(grunt) {
     grunt.util.async.forEachSeries(this.files, function(f, next) {
       var args = [f.dest, '--stdin'].concat(helpers.optsToArgs(options));
 
+      grunt.log.writeln(args)
+
       var max = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -55,6 +55,9 @@ module.exports = function(grunt) {
         exeFile = 'bundle';
       }
 
+      grunt.log.writeln(args)
+      grunt.log.writeln(exeFile)
+
       var slim = grunt.util.spawn({
         cmd: exeFile,
         args: args

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -25,8 +25,6 @@ module.exports = function(grunt) {
       }
       var args = [f.dest, '--stdin'].concat(helpers.optsToArgs(options));
 
-      grunt.log.writeln(args)
-
       var max = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
@@ -60,9 +58,6 @@ module.exports = function(grunt) {
         args.unshift('exec')
         exeFile = 'bundle';
       }
-
-      grunt.log.writeln(args)
-      grunt.log.writeln(exeFile)
 
       var slim = grunt.util.spawn({
         cmd: exeFile,

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -53,8 +53,8 @@ module.exports = function(grunt) {
         nixexe = 'bundle exec ' + nixexe;
       }
 
-      grunt.log.info('exes')
-      grunt.log.info(nixexe)
+      grunt.log.writeln('exes')
+      grunt.log.writeln(nixexe)
 
       var slim = grunt.util.spawn({
         cmd: process.platform === 'win32' ? win32exe : nixexe,

--- a/test/expected/compile-pretty.html
+++ b/test/expected/compile-pretty.html
@@ -6,9 +6,13 @@
     <meta content="author" name="author" />
   </head>
   <body>
-    <h1>Markup examples</h1>
+    <h1>
+      Markup examples
+    </h1>
     <div id="content">
-      <p>This example shows you how a basic Slim file looks like.</p>
+      <p>
+        This example shows you how a basic Slim file looks like.
+      </p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Added an option `bundle exec` to ensure slim is run with the version specified in Gemfile (useful if you need a specific version). Added it to readme, restored working tests (slim has been updated). Added to gitignore Gemfile, Gemfile.lock and .ruby-version files
