### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ grunt.initConfig({
     },
     dev: {                             // Another target
       options: {                       // Target options
-        style: 'expanded'
+        pretty: true
       },
       files: {
         'index.html': 'index.slim',


### PR DESCRIPTION
style: 'expanded' was causing an error, I think pretty: true is the expected behavior
