### PR TITLE
Processing slim files in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Type: `Boolean`
 
 Run `slimrb` preceding it with `bundle exec`.
 
+#### parallelLimit
+Type: 'Integer'
+
+Maximum number of slim files to process in parallel. Default is `1`.
+
 #### compile
 Type: `Boolean`
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "dargs": "^2.0.3"
+    "dargs": "^2.0.3",
+    "async": "~0.9.0"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.4.0",

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -31,8 +31,10 @@ module.exports = function(grunt) {
     }
 
     grunt.verbose.writeflags(options, 'Options');
-    process.stdout.setMaxListeners(parallelLimit);
-    process.stderr.setMaxListeners(parallelLimit);
+    if (parallelLimit > 10) {
+      process.stdout.setMaxListeners(parallelLimit);
+      process.stderr.setMaxListeners(parallelLimit);
+    }
 
     async.eachLimit(this.files, parallelLimit, function(f, next) {
       var args = [f.dest, '--stdin'].concat(dargs(options));

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -11,14 +11,17 @@
 module.exports = function(grunt) {
   var path = require('path');
   var dargs = require('dargs');
+  var async     = require('async');
 
   grunt.registerMultiTask('slim', 'Compile Slim to HTML', function() {
     var options = this.options();
     var cb = this.async();
 
     grunt.verbose.writeflags(options, 'Options');
+    process.stdout.setMaxListeners(0);
+    process.stderr.setMaxListeners(0);
 
-    grunt.util.async.forEachSeries(this.files, function(f, next) {
+    async.each(this.files, function(f, next) {
       var bundleExec = options.bundleExec;
       if (bundleExec) {
         delete options.bundleExec;

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -12,17 +12,25 @@ module.exports = function(grunt) {
   var path = require('path');
   var dargs = require('dargs');
   var async     = require('async');
-  var asyncLimit = 10;
 
   grunt.registerMultiTask('slim', 'Compile Slim to HTML', function() {
     var options = this.options();
     var cb = this.async();
+    var parallelLimit;
+
+    if (options.parallelLimit) {
+      parallelLimit = options.parallelLimit;
+      delete options.parallelLimit;
+    } else {
+      parallelLimit = 1;
+    }
+
 
     grunt.verbose.writeflags(options, 'Options');
-    process.stdout.setMaxListeners(asyncLimit);
-    process.stderr.setMaxListeners(asyncLimit);
+    process.stdout.setMaxListeners(parallelLimit);
+    process.stderr.setMaxListeners(parallelLimit);
 
-    async.eachLimit(this.files, asyncLimit, function(f, next) {
+    async.eachLimit(this.files, parallelLimit, function(f, next) {
       var bundleExec = options.bundleExec;
       if (bundleExec) {
         delete options.bundleExec;

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -25,16 +25,16 @@ module.exports = function(grunt) {
       parallelLimit = 1;
     }
 
+    var bundleExec = options.bundleExec;
+    if (bundleExec) {
+      delete options.bundleExec;
+    }
 
     grunt.verbose.writeflags(options, 'Options');
     process.stdout.setMaxListeners(parallelLimit);
     process.stderr.setMaxListeners(parallelLimit);
 
     async.eachLimit(this.files, parallelLimit, function(f, next) {
-      var bundleExec = options.bundleExec;
-      if (bundleExec) {
-        delete options.bundleExec;
-      }
       var args = [f.dest, '--stdin'].concat(dargs(options));
 
       var max = f.src.filter(function(filepath) {

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -40,14 +40,14 @@ module.exports = function(grunt) {
         return grunt.file.read(filepath);
       }).join(grunt.util.normalizelf(grunt.util.linefeed));
 
-      // support for varibales
-      var varibales = "";
+      // support for variables
+      var variables = "";
 
       grunt.util._.forEach(options.variables, function(val,key){
-        varibales = varibales + '- ' + key + '="' + val + '"' + "\n";
+        variables = variables + '- ' + key + '="' + val + '"' + "\n";
       });
 
-      max = varibales + max;
+      max = variables + max;
 
       // Make sure grunt creates the destination folders
       grunt.file.write(f.dest, '');

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -12,16 +12,17 @@ module.exports = function(grunt) {
   var path = require('path');
   var dargs = require('dargs');
   var async     = require('async');
+  var asyncLimit = 10;
 
   grunt.registerMultiTask('slim', 'Compile Slim to HTML', function() {
     var options = this.options();
     var cb = this.async();
 
     grunt.verbose.writeflags(options, 'Options');
-    process.stdout.setMaxListeners(0);
-    process.stderr.setMaxListeners(0);
+    process.stdout.setMaxListeners(asyncLimit);
+    process.stderr.setMaxListeners(asyncLimit);
 
-    async.each(this.files, function(f, next) {
+    async.eachLimit(this.files, asyncLimit, function(f, next) {
       var bundleExec = options.bundleExec;
       if (bundleExec) {
         delete options.bundleExec;

--- a/tasks/slim.js
+++ b/tasks/slim.js
@@ -57,8 +57,8 @@ module.exports = function(grunt) {
       var exeFile = process.platform === 'win32' ? win32exe : nixexe;
 
       if (bundleExec) {
-        args.unshift(exeFile)
-        args.unshift('exec')
+        args.unshift(exeFile);
+        args.unshift('exec');
         exeFile = 'bundle';
       }
 


### PR DESCRIPTION
Introduces `parallelLimit` option to allow processing slim files in parallel.
Allows a significant speed boost.

Also fixes using the `bundleExec` option.
